### PR TITLE
Add option to skip collecting index stats

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict'
 var rest = require('restler')
-var urls = ['/_cluster/health', '/_stats?level=shards']
+var indexStatsURL = '/_stats?level=shards';
+var urls = ['/_cluster/health']
 var localNodeStatsURL = '/_nodes/_local/stats';
 var nodesStatsURL = '/_nodes/stats';
 // '/_stats/indexing,store,search,merge,refresh,flush,docs,get?level=shards'
@@ -23,6 +24,9 @@ function ElasticsearchStats (config, eventEmitter) {
     urls.push(nodesStatsURL);
   } else {
     urls.push(localNodeStatsURL);
+  }
+  if (!config.skipIndexStats) {
+    urls.push(indexStatsURL);
   }
 }
 


### PR DESCRIPTION
Index stats, especially on the shard level, can take a lot of space. For many use-cases it's enough to get the node-level stats. This PR adds a new `skipIndexStats` option - when set to `true`, we'll only collect the nodes stats.